### PR TITLE
글 삭제시 첨부 이미지 제거

### DIFF
--- a/src/views/JobDetail.vue
+++ b/src/views/JobDetail.vue
@@ -97,16 +97,37 @@ const handleApply = async () => {
 
 };
 
+// 이미지 삭제 함수
+const deleteImage = async () => {
+  const { data, error } = await supabase
+    .from('job_posts')
+    .select('img_url')
+    .eq('id', id)
+    .single();
+  console.log(data);
+
+  if(data.img_url) {
+    const { error: img_del_err } = await supabase
+      .storage
+      .from('images')
+      .remove([data.img_url.split('/').pop()]); // img_url에서 파일 이름 추출
+  }
+}
+
 const handleDelete = async () => {
   // 삭제 확인 대화상자 표시
   const conf = confirm('정말 삭제하시겠습니까?');
   if (!conf) return;
+
+  // 이미지 삭제 함수 호출
+  await deleteImage();
 
   const { error } = await supabase
     .from('job_posts')
     .delete()
     .eq('id', id);
     console.log(error);
+    
     if (error) {
       alert(error.message);
       return;


### PR DESCRIPTION
## 이미지 삭제 함수 추가

---

삭제할 글에 해당하는 이미지가 저장된 경로를 알아야 합니다.

그래서 `job_posts`에서 글 데이터를 가져와 이미지 경로를 읽어옵니다.

첨부 이미지가 있으면 버킷에서 삭제해 줍니다.

```jsx
// JobDetail.vue

// 이미지 삭제 함수
const deleteImage = async () => {
	// 현재 글(id)에 포함된 이미지 URL을 가져옵니다
  const { data, error } = await supabase
    .from('job_posts')
    .select('img_url')
    .eq('id', id)
    .single();
  console.log(data);

	// 첨부 이미ㅣ지가 있으면 버킷에서 이미지 삭제
  if(data.img_url) {
    const { error: img_del_err } = await supabase
      .storage
      .from('images')
      .remove([data.img_url.split('/').pop()]); // img_url에서 파일 이름 추출
  }
}
```

글 데이터를 삭제하기 전에 미리 글 데이터에 있는 이미지 주소를 참조해서 지워줍니다.

```jsx
const handleDelete = async () => {
  // 삭제 확인 대화상자 표시
  ...

  await deleteImage(); // 이미지 삭제 함수 호출

  const { error } = await supabase
    .from('job_posts')
    .delete()
    .eq('id', id);
    ...
}
```