### PR TITLE
프로필 수정 - 이전 이미지 제거하기

### DIFF
--- a/src/views/UpdateProfile.vue
+++ b/src/views/UpdateProfile.vue
@@ -30,6 +30,7 @@ const file = ref(null); // 오픈한 이미지 객체 저장 변수
 const previewImage = ref(null); // 이미지 미리보기 변수
 const img_url = ref(null); // 이미지 url 저장 변수
 const userId = ref(null); // 로그인한 유저 아이디(auth) 저장 변수(user_info 테이블 위치 참조용)
+const prev_img_url = ref(null); // -이전 이미지 url 저장 변수
 
 // 폼 제출 핸들러
 const handleSubmit = async () => {
@@ -67,6 +68,16 @@ const handleSubmit = async () => {
       if (error) {
         console.log(error, '프로필 수정 실패');
       } else {
+        // 이전 이미지 삭제
+        if(prev_img_url.value) {
+          const { error:deleteErr } = await supabase
+            .storage
+            .from('images')
+            .remove(`profile/${[prev_img_url.value.split('/').pop()]}`);
+          if (deleteErr) {
+            console.log(deleteErr, '이전 이미지 삭제 실패');
+          }
+        }
         alert('프로필 수정 완료');
         router.push('/user-profile');
       }
@@ -120,6 +131,7 @@ onMounted(async () => {
     console.log(data);
     text.value = data.text;
     img_url.value = data.profile_img; // 이미지 주소 저장
+    prev_img_url.value = data.profile_img; // - 이전 이미지 주소 저장
   } else {
     alert('로그인이 필요합니다.');
     router.push('/');


### PR DESCRIPTION
post 정보와 마찬가지로 이미지를 업데이트 하면 버킷에 이전 이미지 찌거기가 남게 됩니다.

새로 이미지를 첨부하여 업데이트 하는 경우 이전 이미지를 제거해 줍니다.

```jsx
// UpdateProfile.vue
...
const prev_img_url = ref(null); // -이전 이미지 url 저장 변수 추가
```

```jsx
// 폼 제출 핸들러
const handleSubmit = async () => {
  // 파일을 첨부한 경우, images 버킷의 /profile 폴더에 이미지 저장
  if (file.value) {
    ...
    } else {
      // 업로드된 이미지의 URL을 가져옴
      ...
      // user_info 테이블에 text와 이미지 주소 저장
      ...
      
      if (error) {
        console.log(error, '프로필 수정 실패');
      } else {
        // 업로드 성공시 이전 이미지 삭제
        if(prev_img_url.value) {
          const { error:deleteErr } = await supabase
            .storage
            .from('images')
            .remove(`profile/${[prev_img_url.value.split('/').pop()]}`); // 파일명만 추출
          if (deleteErr) {
            console.log(deleteErr, '이전 이미지 삭제 실패');
          }
        }
        alert('프로필 수정 완료');
        router.push('/user-profile');
      }
    }
  } else {
    // 파일을 첨부하지 않은 경우, user_info 테이블에 text만 저장
    ...
  } // end if(file.value)

} // end func
```